### PR TITLE
Add weather ETL project scaffolding

### DIFF
--- a/weather-etl/.env.example
+++ b/weather-etl/.env.example
@@ -1,0 +1,14 @@
+# Identify your app + contact as required by MET (api.met.no)
+MET_USER_AGENT="bir-weather-etl/0.1 roger@bir.no"
+# Comma-separated: name:lat:lon:altitude
+LOCATIONS="Bergen:60.392:5.324:12,Oslo:59.913:10.752:23"
+
+# Local SQL Server container
+DB_SERVER="localhost,1433"
+DB_DATABASE="weather"
+DB_USER="sa"
+DB_PASSWORD="Your_strong_Passw0rd!"
+USE_MI=false
+
+# Cron for APScheduler (default: every 30 minutes)
+SCHEDULE_CRON="*/30 * * * *"

--- a/weather-etl/Makefile
+++ b/weather-etl/Makefile
@@ -1,0 +1,16 @@
+.PHONY: run build test fmt
+
+run:
+	python -m weather_ingest.main
+
+build:
+	docker build -f docker/Dockerfile -t weather-etl:local .
+
+dev-up:
+	docker compose -f docker/docker-compose.yml up --build
+
+test:
+	pytest -q
+
+fmt:
+	ruff check --fix . && black .

--- a/weather-etl/README.md
+++ b/weather-etl/README.md
@@ -1,0 +1,30 @@
+# weather-etl
+
+Minimal Python ETL that fetches weather forecasts from MET (api.met.no) and stores both raw JSON and flattened point data in SQL (Azure SQL-compatible). Local dev uses Docker Compose.
+
+## Quick start (local)
+1. Copy env file:
+   ```bash
+   cp .env.example .env
+```
+
+Set a strong `SA_PASSWORD` if you change it in compose.
+2. Start services:
+
+```bash
+docker compose -f docker/docker-compose.yml up --build
+```
+
+3. The app will create schema and fetch for the configured `LOCATIONS`. Check logs and connect to SQL on `localhost,1433` (db `weather`).
+
+## Notes
+
+* **User-Agent** must identify your app + contact per MET terms.
+* The client uses `If-Modified-Since` to reduce calls; respect rate limits.
+* In Azure, prefer passwordless with Managed Identity (set `USE_MI=true`).
+
+## Tests
+
+```bash
+pytest -q
+```

--- a/weather-etl/docker/Dockerfile
+++ b/weather-etl/docker/Dockerfile
@@ -1,0 +1,19 @@
+FROM python:3.11-slim
+
+# System deps + Microsoft repo for msodbcsql18
+RUN apt-get update \
+ && apt-get install -y curl gnupg apt-transport-https unixodbc-dev build-essential \
+ && curl -sSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
+ && echo "deb [arch=amd64] https://packages.microsoft.com/debian/12/prod bookworm main" > /etc/apt/sources.list.d/microsoft.list \
+ && apt-get update \
+ && apt-get install -y msodbcsql18 \
+ && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+COPY pyproject.toml /app/
+RUN pip install --no-cache-dir -U pip && pip install --no-cache-dir .
+
+COPY src/ /app/src/
+ENV PYTHONPATH=/app/src
+
+CMD ["python", "-m", "weather_ingest.main"]

--- a/weather-etl/docker/docker-compose.yml
+++ b/weather-etl/docker/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.9"
+services:
+  sql:
+    image: mcr.microsoft.com/mssql/server:2022-latest
+    environment:
+      - ACCEPT_EULA=Y
+      - SA_PASSWORD=Your_strong_Passw0rd!
+    ports: ["1433:1433"]
+    healthcheck:
+      test: ["CMD-SHELL", "/opt/mssql-tools18/bin/sqlcmd -C -S localhost -U sa -P 'Your_strong_Passw0rd!' -Q 'SELECT 1' || exit 1"]
+      interval: 10s
+      retries: 20
+
+  app:
+    build:
+      context: ..
+      dockerfile: docker/Dockerfile
+    env_file: ../.env
+    depends_on:
+      sql:
+        condition: service_healthy

--- a/weather-etl/infra/bicep/main.bicep
+++ b/weather-etl/infra/bicep/main.bicep
@@ -1,0 +1,33 @@
+// High-level composition (example). Adjust parameters and API versions for your environment.
+param location string = resourceGroup().location
+param sqlServerName string
+param dbName string = 'weather'
+param aadAdminObjectId string
+param containerAppEnvId string  // existing Container Apps Environment resourceId
+param acrServer string          // e.g. myregistry.azurecr.io
+param image string              // e.g. myregistry.azurecr.io/weather-etl:latest
+param schedule string = '5,35 * * * *'
+
+module sql '../modules/sql.bicep' = {
+  name: 'sql'
+  params: {
+    location: location
+    sqlServerName: sqlServerName
+    dbName: dbName
+    aadAdminObjectId: aadAdminObjectId
+  }
+}
+
+module job '../modules/containerapp-job.bicep' = {
+  name: 'job'
+  params: {
+    location: location
+    jobName: 'weather-etl-job'
+    containerAppEnvId: containerAppEnvId
+    acrServer: acrServer
+    image: image
+    schedule: schedule
+    sqlServerFqdn: sql.outputs.sqlFqdn
+    dbName: dbName
+  }
+}

--- a/weather-etl/infra/bicep/modules/containerapp-job.bicep
+++ b/weather-etl/infra/bicep/modules/containerapp-job.bicep
@@ -1,0 +1,45 @@
+// NOTE: Verify API versions before deploying; this is a starter template.
+param location string
+param jobName string
+param containerAppEnvId string
+param acrServer string
+param image string
+param schedule string  // e.g. "5,35 * * * *" for twice per hour
+param sqlServerFqdn string
+param dbName string
+
+resource job 'Microsoft.App/jobs@2024-02-02-preview' = {
+  name: jobName
+  location: location
+  identity: { type: 'SystemAssigned' }
+  properties: {
+    environmentId: containerAppEnvId
+    configuration: {
+      triggerType: 'Schedule'
+      scheduleTriggerConfig: {
+        cronExpression: schedule
+        parallelism: 1
+      }
+      registries: [
+        {
+          server: acrServer
+          identity: 'system'
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'weather'
+          image: image
+          env: [
+            { name: 'USE_MI', value: 'true' },
+            { name: 'DB_SERVER', value: '${sqlServerFqdn},1433' },
+            { name: 'DB_DATABASE', value: dbName },
+            { name: 'MET_USER_AGENT', value: 'bir-weather-etl/0.1 roger@bir.no' }
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/weather-etl/infra/bicep/modules/sql.bicep
+++ b/weather-etl/infra/bicep/modules/sql.bicep
@@ -1,0 +1,36 @@
+// NOTE: Verify API versions with Azure docs before deploying.
+param location string
+param sqlServerName string
+param dbName string
+param aadAdminObjectId string  // Entra ID objectId for SQL AAD admin (group or user)
+
+resource sqlServer 'Microsoft.Sql/servers@2023-08-01-preview' = {
+  name: sqlServerName
+  location: location
+  properties: {
+    publicNetworkAccess: 'Enabled'
+    minimalTlsVersion: '1.2'
+  }
+  identity: { type: 'SystemAssigned' }
+}
+
+resource aadAdmin 'Microsoft.Sql/servers/administrators@2022-05-01-preview' = {
+  name: 'activeDirectory'
+  parent: sqlServer
+  properties: {
+    administratorType: 'ActiveDirectory'
+    login: 'AadAdmin'
+    sid: aadAdminObjectId
+    tenantId: tenant().tenantId
+  }
+}
+
+resource db 'Microsoft.Sql/servers/databases@2024-11-01-preview' = {
+  name: '${sqlServerName}/${dbName}'
+  location: location
+  sku: {
+    name: 'S0'
+  }
+}
+
+output sqlFqdn string = sqlServer.properties.fullyQualifiedDomainName

--- a/weather-etl/pyproject.toml
+++ b/weather-etl/pyproject.toml
@@ -1,0 +1,22 @@
+[project]
+name = "weather-etl"
+version = "0.1.0"
+description = "Simple weather ETL: MET Locationforecast -> Azure SQL"
+requires-python = ">=3.11"
+dependencies = [
+  "httpx>=0.27",
+  "backoff>=2.2",
+  "pydantic>=2",
+  "SQLAlchemy>=2.0",
+  "pyodbc>=5.1",
+  "python-dotenv>=1.0",
+  "apscheduler>=3.10",
+  "azure-identity>=1.17"
+]
+
+[tool.black]
+line-length = 100
+
+[tool.ruff]
+line-length = 100
+lint.select = ["E", "F", "I"]

--- a/weather-etl/src/weather_ingest/__init__.py
+++ b/weather-etl/src/weather_ingest/__init__.py
@@ -1,0 +1,1 @@
+# Package init

--- a/weather-etl/src/weather_ingest/config.py
+++ b/weather-etl/src/weather_ingest/config.py
@@ -1,0 +1,20 @@
+from pydantic import BaseSettings, Field
+
+class Settings(BaseSettings):
+    # MET / api.met.no
+    met_user_agent: str = Field(..., alias="MET_USER_AGENT")  # e.g., "your-app/0.1 you@company.no"
+    # Comma-separated list: name:lat:lon:alt
+    locations: str = Field(..., alias="LOCATIONS")
+
+    # Database (local uses username/password; Azure uses managed identity)
+    db_server: str = Field(..., alias="DB_SERVER")  # "localhost,1433" or "<server>.database.windows.net"
+    db_database: str = Field(..., alias="DB_DATABASE")
+    db_user: str | None = Field(None, alias="DB_USER")
+    db_password: str | None = Field(None, alias="DB_PASSWORD")
+    use_managed_identity: bool = Field(False, alias="USE_MI")
+
+    schedule_cron: str = Field("*/30 * * * *", alias="SCHEDULE_CRON")  # every 30 minutes
+
+    model_config = {"env_file": ".env", "extra": "ignore"}
+
+settings = Settings()

--- a/weather-etl/src/weather_ingest/db.py
+++ b/weather-etl/src/weather_ingest/db.py
@@ -1,0 +1,44 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from .config import settings
+import pyodbc
+import struct
+import urllib.parse
+from azure.identity import DefaultAzureCredential
+
+
+def _build_conn_str() -> str:
+    driver = "ODBC Driver 18 for SQL Server"
+    base = (
+        f"Driver={{{driver}}};Server={settings.db_server};Database={settings.db_database};"
+        "Encrypt=yes;TrustServerCertificate=no;Connection Timeout=30;"
+    )
+    return base
+
+
+def _token_struct(token: str) -> bytes:
+    # SQL Server expects an access token as UTF-16-LE prefixed with its length
+    token_bytes = token.encode("utf-16-le")
+    return struct.pack("=i", len(token_bytes)) + token_bytes
+
+
+def _create_engine():
+    base = _build_conn_str()
+    if settings.use_managed_identity:
+        cred = DefaultAzureCredential()
+        # Scope for Azure SQL
+        access_token = cred.get_token("https://database.windows.net/.default").token
+
+        def connect():
+            return pyodbc.connect(base, attrs_before={1256: _token_struct(access_token)})
+
+        return create_engine("mssql+pyodbc://", creator=connect, pool_pre_ping=True)
+    else:
+        conn = base + f"UID={settings.db_user};PWD={settings.db_password};"
+        return create_engine(
+            "mssql+pyodbc:///?odbc_connect=" + urllib.parse.quote_plus(conn), pool_pre_ping=True
+        )
+
+
+engine = _create_engine()
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)

--- a/weather-etl/src/weather_ingest/main.py
+++ b/weather-etl/src/weather_ingest/main.py
@@ -1,0 +1,72 @@
+import time
+import random
+from datetime import datetime, timezone
+from apscheduler.schedulers.blocking import BlockingScheduler
+from .config import settings
+from . import met_client, transform
+from .db import SessionLocal, engine
+from .models import Base, Location, ForecastRaw, ForecastPoint
+
+
+def ensure_schema():
+    Base.metadata.create_all(bind=engine)
+
+
+def seed_locations(sess: SessionLocal):
+    if sess.query(Location).count() == 0:
+        for entry in settings.locations.split(","):
+            name, lat, lon, alt = entry.split(":")
+            sess.add(
+                Location(name=name, lat=float(lat), lon=float(lon), altitude_m=int(alt))
+            )
+        sess.commit()
+
+
+def run_once():
+    ensure_schema()
+    s = SessionLocal()
+    try:
+        seed_locations(s)
+        # Fetch per location with caching and jitter
+        for loc in s.query(Location).all():
+            last = (
+                s.query(ForecastRaw)
+                .filter(ForecastRaw.location_id == loc.id)
+                .order_by(ForecastRaw.id.desc())
+                .first()
+            )
+            last_mod = last.last_modified if last else None
+            doc, lm = met_client.fetch(loc.lat, loc.lon, loc.altitude_m, last_mod)
+            if not doc:
+                continue  # Not modified
+
+            s.add(
+                ForecastRaw(
+                    location_id=loc.id,
+                    fetched_at=datetime.now(timezone.utc),
+                    last_modified=lm,
+                    payload_json=doc,
+                )
+            )
+            for p in transform.extract_points(doc):
+                s.merge(ForecastPoint(location_id=loc.id, **p))
+            s.commit()
+            time.sleep(random.uniform(0.2, 1.0))  # jitter between calls
+    finally:
+        s.close()
+
+
+def main():
+    if settings.schedule_cron:
+        minute, hour, dom, mon, dow = settings.schedule_cron.split()
+        sched = BlockingScheduler()
+        sched.add_job(
+            run_once, "cron", minute=minute, hour=hour, day=dom, month=mon, day_of_week=dow
+        )
+        sched.start()
+    else:
+        run_once()
+
+
+if __name__ == "__main__":
+    main()

--- a/weather-etl/src/weather_ingest/met_client.py
+++ b/weather-etl/src/weather_ingest/met_client.py
@@ -1,0 +1,29 @@
+import httpx
+import backoff
+from .config import settings
+
+BASE = "https://api.met.no/weatherapi/locationforecast/2.0/compact"
+
+
+def _headers(last_modified: str | None):
+    h = {
+        "User-Agent": settings.met_user_agent,
+        "Accept-Encoding": "gzip, deflate",
+    }
+    if last_modified:
+        h["If-Modified-Since"] = last_modified
+    return h
+
+
+@backoff.on_exception(backoff.expo, (httpx.HTTPError,), max_time=60)
+def fetch(lat: float, lon: float, altitude: int | None, last_modified: str | None):
+    params = {"lat": round(lat, 4), "lon": round(lon, 4)}
+    if altitude is not None:
+        params["altitude"] = int(altitude)
+    with httpx.Client(timeout=20.0, headers=_headers(last_modified)) as client:
+        r = client.get(BASE, params=params)
+        if r.status_code == 304:
+            return None, last_modified
+        r.raise_for_status()
+        lm = r.headers.get("Last-Modified")
+        return r.json(), lm

--- a/weather-etl/src/weather_ingest/models.py
+++ b/weather-etl/src/weather_ingest/models.py
@@ -1,0 +1,37 @@
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
+from sqlalchemy import String, Integer, Float, DateTime, JSON
+from datetime import datetime
+
+class Base(DeclarativeBase):
+    pass
+
+class Location(Base):
+    __tablename__ = "locations"
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(100))
+    lat: Mapped[float] = mapped_column(Float)
+    lon: Mapped[float] = mapped_column(Float)
+    altitude_m: Mapped[int | None] = mapped_column(Integer, nullable=True)
+
+class ForecastRaw(Base):
+    __tablename__ = "forecast_raw"
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    location_id: Mapped[int] = mapped_column()
+    fetched_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    last_modified: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    payload_json = mapped_column(JSON)
+
+class ForecastPoint(Base):
+    __tablename__ = "forecast_point"
+    # Composite primary key to allow upsert via session.merge()
+    location_id: Mapped[int] = mapped_column(primary_key=True)
+    forecast_time: Mapped[datetime] = mapped_column(DateTime(timezone=True), primary_key=True)
+
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+    temp_c: Mapped[float | None]
+    wind_mps: Mapped[float | None]
+    wind_from_deg: Mapped[float | None]
+    precip_mm_1h: Mapped[float | None]
+    precip_mm_6h: Mapped[float | None]
+    cloud_area_frac: Mapped[float | None]
+    symbol_code: Mapped[str | None] = mapped_column(String(40))

--- a/weather-etl/src/weather_ingest/transform.py
+++ b/weather-etl/src/weather_ingest/transform.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+
+
+def _parse_ts(s: str) -> datetime:
+    # Handle trailing 'Z' as UTC
+    if s.endswith("Z"):
+        s = s.replace("Z", "+00:00")
+    return datetime.fromisoformat(s)
+
+
+def extract_points(doc: dict):
+    meta_updated = doc["properties"]["meta"]["updated_at"]
+    updated_at = _parse_ts(meta_updated)
+
+    for t in doc["properties"]["timeseries"]:
+        ts = _parse_ts(t["time"])
+        inst = t["data"]["instant"]["details"]
+        next1 = (t["data"].get("next_1_hours") or {}).get("details", {})
+        next6 = (t["data"].get("next_6_hours") or {}).get("details", {})
+        sym = (t["data"].get("next_1_hours") or {}).get("summary", {}).get("symbol_code")
+        yield {
+            "forecast_time": ts,
+            "updated_at": updated_at,
+            "temp_c": inst.get("air_temperature"),
+            "wind_mps": inst.get("wind_speed"),
+            "wind_from_deg": inst.get("wind_from_direction"),
+            "precip_mm_1h": next1.get("precipitation_amount"),
+            "precip_mm_6h": next6.get("precipitation_amount"),
+            "cloud_area_frac": inst.get("cloud_area_fraction"),
+            "symbol_code": sym,
+        }

--- a/weather-etl/tests/test_smoke.py
+++ b/weather-etl/tests/test_smoke.py
@@ -1,0 +1,4 @@
+from weather_ingest.config import settings
+
+def test_config_has_user_agent():
+    assert settings.met_user_agent


### PR DESCRIPTION
## Summary
- scaffold weather ETL pipeline with pydantic-based config and APScheduler
- add MET API client, SQLAlchemy models, and transformation logic
- include Docker and Bicep infrastructure for local dev and Azure deployment

## Testing
- `MET_USER_AGENT='x' LOCATIONS='A:1:2:3' DB_SERVER='x' DB_DATABASE='y' PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bedcbe7cec8323947c3de27e8d12ab