### PR TITLE
Fix Docker build and update pydantic settings

### DIFF
--- a/weather-etl/docker/Dockerfile
+++ b/weather-etl/docker/Dockerfile
@@ -4,8 +4,8 @@ FROM python:3.11
 # System deps + Microsoft repo for msodbcsql18
 RUN apt-get update \
  && apt-get install -y curl gnupg apt-transport-https unixodbc-dev build-essential \
- && curl -sSL https://packages.microsoft.com/keys/microsoft.asc | apt-key add - \
- && echo "deb [arch=amd64] https://packages.microsoft.com/debian/12/prod bookworm main" > /etc/apt/sources.list.d/microsoft.list \
+ && curl -sSL https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor -o /usr/share/keyrings/microsoft.gpg \
+ && echo "deb [arch=amd64 signed-by=/usr/share/keyrings/microsoft.gpg] https://packages.microsoft.com/debian/12/prod bookworm main" > /etc/apt/sources.list.d/microsoft.list \
  && apt-get update \
  && apt-get install -y msodbcsql18 \
  && rm -rf /var/lib/apt/lists/*

--- a/weather-etl/pyproject.toml
+++ b/weather-etl/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
   "httpx>=0.27",
   "backoff>=2.2",
   "pydantic>=2",
+  "pydantic-settings>=2",
   "SQLAlchemy>=2.0",
   "pyodbc>=5.1",
   "python-dotenv>=1.0",

--- a/weather-etl/src/weather_ingest/config.py
+++ b/weather-etl/src/weather_ingest/config.py
@@ -1,4 +1,5 @@
-from pydantic import BaseSettings, Field
+from pydantic_settings import BaseSettings
+from pydantic import Field
 
 class Settings(BaseSettings):
     # MET / api.met.no


### PR DESCRIPTION
## Summary
- replace removed apt-key with modern GPG key handling for Microsoft repo
- use pydantic-settings for configuration and add dependency

## Testing
- `make test`
- `docker build -f docker/Dockerfile -t weather-etl:local .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bee3c409d4832395bb6bc40aaa9a09