### PR TITLE
Ensure database is created before initializing schema

### DIFF
--- a/weather-etl/src/weather_ingest/db.py
+++ b/weather-etl/src/weather_ingest/db.py
@@ -9,10 +9,21 @@ from sqlalchemy.orm import sessionmaker
 from .config import settings
 
 
-def _build_conn_str() -> str:
+def _build_conn_str(database: str | None = settings.db_database) -> str:
+    """Construct a basic ODBC connection string.
+
+    Parameters
+    ----------
+    database:
+        Name of the database to connect to. If ``None`` then no explicit
+        database is specified which allows connecting to the server to perform
+        server-wide operations such as creating databases.
+    """
+
     driver = "ODBC Driver 18 for SQL Server"
+    db_part = f"Database={database};" if database else ""
     base = (
-        f"Driver={{{driver}}};Server={settings.db_server};Database={settings.db_database};"
+        f"Driver={{{driver}}};Server={settings.db_server};{db_part}"
         "Encrypt=yes;TrustServerCertificate=Yes;Connection Timeout=30;"
     )
     return base
@@ -40,6 +51,28 @@ def _create_engine():
         return create_engine(
             "mssql+pyodbc:///?odbc_connect=" + urllib.parse.quote_plus(conn), pool_pre_ping=True
         )
+
+
+def ensure_database() -> None:
+    """Create the target database if it does not already exist."""
+
+    # Connect to the server's ``master`` database which always exists
+    base = _build_conn_str("master")
+
+    if settings.use_managed_identity:
+        cred = DefaultAzureCredential()
+        token = cred.get_token("https://database.windows.net/.default").token
+        connect_args = {"attrs_before": {1256: _token_struct(token)}}
+    else:
+        base += f"UID={settings.db_user};PWD={settings.db_password};"
+        connect_args = {}
+
+    with pyodbc.connect(base, **connect_args) as conn:
+        cur = conn.cursor()
+        cur.execute(
+            f"IF DB_ID(N'{settings.db_database}') IS NULL CREATE DATABASE [{settings.db_database}]"
+        )
+        conn.commit()
 
 
 engine = _create_engine()

--- a/weather-etl/src/weather_ingest/main.py
+++ b/weather-etl/src/weather_ingest/main.py
@@ -7,13 +7,14 @@ from sqlalchemy.exc import OperationalError
 
 from . import met_client, transform
 from .config import settings
-from .db import SessionLocal, engine
+from .db import SessionLocal, engine, ensure_database
 from .models import Base, ForecastPoint, ForecastRaw, Location
 
 
 def ensure_schema(retries: int = 5, delay: int = 1) -> None:
     for attempt in range(1, retries + 1):
         try:
+            ensure_database()
             Base.metadata.create_all(bind=engine)
             break
         except OperationalError:


### PR DESCRIPTION
## Summary
- Build connection strings with optional database
- Add helper to create target database if it doesn't exist
- Ensure DB exists before running schema migrations

## Testing
- `pytest -q`
- `make fmt`

------
https://chatgpt.com/codex/tasks/task_e_68bf059c128c83238960376bd4133371